### PR TITLE
Add support for different id types

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -1,0 +1,7 @@
+githubRepoOwner: inigolabs
+githubRepoName: entbrowse
+githubHost: github.com
+requireChecks: false
+requireApproval: true
+githubRemote: origin
+githubBranch: master

--- a/browse.go
+++ b/browse.go
@@ -111,7 +111,7 @@ func (s *server) listHandler(w http.ResponseWriter, r *http.Request) {
 func (s *server) entityHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	entityType := chi.URLParam(r, "type")
-	entityID, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	entityID := s.browser.ConvertID(entityType, chi.URLParam(r, "id"))
 	w.Header().Add("Content-Type", "text/html")
 	_, err := w.Write(htmlHeader)
 	check(err)
@@ -219,7 +219,7 @@ func reflectStructValues(obj interface{}) []interface{} {
 		if v.Field(i).CanInterface() {
 			name := v.Type().Field(i).Name
 			if name == "ID" {
-				val := fmt.Sprint(v.Field(i).Interface().(int64))
+				val := fmt.Sprint(v.Field(i).Interface())
 				link := linkify(val, "/"+typeName+"/"+val)
 				out = append(out, link)
 			} else if name != "Edges" {

--- a/ent.go.tmpl
+++ b/ent.go.tmpl
@@ -22,6 +22,38 @@ func (browse) Types() []string {
 	}
 }
 
+func (browse) ConvertID(typeName string, id string) interface{} {
+	switch typeName {
+	{{range $node := $.Nodes}}
+	case "{{$node.Name}}":
+		return convertID("{{$node.ID.Type}}", id)
+	{{- end}}
+	default:
+		panic("invalid typename: " + typeName)
+	}
+}
+
+func convertID(idType string, id string) interface{} {
+	switch idType{
+		case "int":
+			id_, err := strconv.Atoi(id)
+			if err != nil {
+				panic(err)
+			}
+			return id_
+		case "int64":
+			id_, err := strconv.ParseInt(id, 10, 64)
+			if err != nil {
+				panic(err)
+			}
+			return id_
+		case "string":
+			return id
+		default:
+			panic("unsupported id type: " + idType)
+	}
+}
+
 func (browse) Schema(typeName string) ent.Interface {
 	switch typeName {
 	{{range $node := $.Nodes}}
@@ -52,13 +84,18 @@ func (b *browse) List(ctx context.Context, entityType string) interface{} {
 	panic(fmt.Errorf("unknown entity type %s", entityType))
 }
 
-func (b *browse) Object(ctx context.Context, entityType string, entityID int64) interface{} {
+func (b *browse) Object(ctx context.Context, entityType string, entityID interface{}) interface{} {
 	switch entityType {
     {{range $node := $.Nodes}}
 	case "{{$node.Name}}":
-		return b.ent.{{$node.Name}}.Query().{{range $node.Edges}}
-		With{{pascal .Name}}().{{end}}
-		Where({{lower $node.Name}}.IDEQ(entityID)).OnlyX(ctx)
+		switch id := entityID.(type) {
+			case {{ $node.ID.Type }}:
+				return b.ent.{{$node.Name}}.Query().{{range $node.Edges}}
+				With{{pascal .Name}}().{{end}}
+				Where({{lower $node.Name}}.IDEQ(id)).OnlyX(ctx)
+			default:
+				panic(fmt.Errorf("invalid id type: %T, expecting {{ $node.ID.Type }}", id))
+		}
     {{- end -}}
 	}
 	panic(fmt.Errorf("unknown entity type %s", entityType))

--- a/interface.go
+++ b/interface.go
@@ -4,11 +4,20 @@ import (
 	"context"
 )
 
-// Browser is implemented by ent to allow for browsing all the
-//  entities in the ent schema.
+// Browser is implemented by ent to allow for browsing all the entities in the ent schema.
 type Browser interface {
+	// Types returns the name of all the ent schema types
 	Types() []string
+
+	// ConvertID converts a string id to the native golang type
+	ConvertID(typeName string, id string) interface{}
+
+	// Count returns the number of entities of a particular type
 	Count(ctx context.Context, entityType string) int
+
+	// List returns a list of entities
 	List(ctx context.Context, entityType string) interface{}
-	Object(ctx context.Context, typeName string, id int64) interface{}
+
+	// Object returns a particualr entity including all it's edges
+	Object(ctx context.Context, typeName string, id interface{}) interface{}
 }


### PR DESCRIPTION
Currently supports int, int64 and string entity ids

---

**Stack**:
- #2
- #1 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*